### PR TITLE
reviewer guideline URL fix

### DIFF
--- a/docs/pages/conferences.md
+++ b/docs/pages/conferences.md
@@ -20,7 +20,7 @@ The open exchange of ideas and respectful, harassment-free scientific debate are
 central to ISMIR. In their application, conference organisers must agree in writing
 with the [code-of-conduct](http://confcodeofconduct.com). They must
 also agree to publish it on the conference website, and to enforce it throughout
-the conference. Similarly, anonymous peer reviewers must follow the [reviewer guidelines]({{site.base_url}}/reviewer-guidelines) when evaluating paper submissions.
+the conference. Similarly, anonymous peer reviewers must follow the [reviewer guidelines]({{site.base_url}}/reviewer-guidelines/) when evaluating paper submissions.
 
 | Conference | Location | Proceedings |
 | ---------- | --------- | --------- |

--- a/docs/pages/reviewer-guidelines.md
+++ b/docs/pages/reviewer-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: Reviewer guidelines
-permalink: /reviewer-guidelines
+permalink: /reviewer-guidelines/
 ---
 
 # Reviewer guidelines


### PR DESCRIPTION
attempting a quick hotfix to correct reviewer guidelines permalink ... trailing end-slash matches other pages, if doesn't work will roll back and attempt to fix correctly