### PR TITLE
Fix for #37. Updated link for ISMIR 2019 and 2020

### DIFF
--- a/docs/pages/conferences.md
+++ b/docs/pages/conferences.md
@@ -24,8 +24,8 @@ the conference. Similarly, anonymous peer reviewers must follow the [reviewer gu
 
 | Conference | Location | Proceedings |
 | ---------- | --------- | --------- |
-| [ISMIR 2020](https://ismir2020.{{site.domain}}/) | October 11-15, Montr&eacute;al (Canada) | Proceedings to come |
-| [ISMIR 2019](https://ismir2019.{{site.domain}}/) | 4-8 November 2019, Delft (Netherlands) | [Proceedings]({{site.base_url}}/conferences/ismir2019.html) |
+| [ISMIR 2020](http://ismir2020.{{site.domain}}/) | October 11-15, Montr&eacute;al (Canada) | Proceedings to come |
+| [ISMIR 2019](http://ismir2019.{{site.domain}}/) | 4-8 November 2019, Delft (Netherlands) | [Proceedings]({{site.base_url}}/conferences/ismir2019.html) |
 | [ISMIR 2018](https://ismir2018.{{site.domain}}/) | 23-27 September 2018, Paris (France) | [Proceedings]({{site.base_url}}/conferences/ismir2018.html) |
 | [ISMIR 2017](https://ismir2017.{{site.domain}}/) | 23-27 October 2017, Suzhou (China) | [Proceedings]({{site.base_url}}/conferences/ismir2017.html) |
 | [ISMIR 2016](https://ismir2016.{{site.domain}}/) | 7-11 August 2016, New York City (USA) | [Proceedings]({{site.base_url}}/conferences/ismir2016.html) |


### PR DESCRIPTION
Changed https to http for correct redirection