### PR TITLE
ISMIR 2024 Date and Location

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ More details on past conferences and links to the freely accessible proceedings 
 ### Upcoming Conferences
 
 * [ISMIR 2023](https://ismir2023.ismir.net), November 5-9, Milan, Italy
-* ISMIR 2024, San Francisco Bay Area, United States
+* ISMIR 2024, November 10-14, San Francisco, CA, United States
 
 **We are [welcoming bids]({{site.base_url}}/pdfs/Call4Hosting-ISMIR-0.8.pdf) for 2025 and beyond.**
 


### PR DESCRIPTION
This PR updates the location (SF Bay Area -> SF) and adds date (Nov 10-14) for ISMIR 2024 on the main page